### PR TITLE
Fused all pairs of increase/decrease X to a change X which changes a …

### DIFF
--- a/se.liu.ida.l2.tddd78.psc/src/game/BattleField.java
+++ b/se.liu.ida.l2.tddd78.psc/src/game/BattleField.java
@@ -43,43 +43,23 @@ public class BattleField extends GeneralVisibleEntity {
 
     }
 
-    /**
-	 * Performs the activation action of the ship that the cursor hovers over.
-	 *
-	 * @param vx the cursor's virtual x-position
-	 * @param vy the cursor's virtual y-position
-	 */
-	public void activateWithCursor(final float vx, final float vy) {
-		for (StarShip ship: friendlyShips) {
-			if (ship.contains(vx, vy)) {
-				ship.activateWithCursor(vx, vy);
-				return;
-			}
-		}
-		for (StarShip ship: enemyShips) {
-			if (ship.contains(vx, vy)) {
-				ship.activateWithCursor(vx, vy);
-				return;
-			}
-		}
-	}
-
 	/**
-	 * Performs the deactivation action of the ship that the cursor hovers over.
+	 * Tries to change the stat, which indicator bar is at the specified virtual position, with the specified amount.
 	 *
-	 * @param vx the cursor's virtual x-position
-	 * @param vy the cursor's virtual y-position
+	 * @param vx a virtual x-position
+	 * @param vy a virtual y-position
+	 * @param change amount with which the stat is to be changed
 	 */
-	public void deactivateWithCursor(final float vx, final float vy) {
+	public void changeStatIndicatedAt(final float vx, final float vy, int change) {
 		for (StarShip ship: friendlyShips) {
 			if (ship.contains(vx, vy)) {
-				ship.deactivateWithCursor(vx, vy);
+				ship.changeStatIndicatedAt(vx, vy, change);
 				return;
 			}
 		}
 		for (StarShip ship: enemyShips) {
 			if (ship.contains(vx, vy)) {
-				ship.deactivateWithCursor(vx, vy);
+				ship.changeStatIndicatedAt(vx, vy, change);
 				return;
 			}
 		}

--- a/se.liu.ida.l2.tddd78.psc/src/game/Test.java
+++ b/se.liu.ida.l2.tddd78.psc/src/game/Test.java
@@ -74,12 +74,12 @@ public final class Test {
 			if(tick == 1){
 			missileComponent.giveOrder(new Order(1, 2, 3, 3, playerShip));
 			System.out.println("Order has been given");
-				//field.activateWithCursor(gc.getVirtualX(cursorX), gc.getVirtualY(cursorY));
+				//field.increaseStatIndicatedAt(gc.getVirtualX(cursorX), gc.getVirtualY(cursorY));
 
 			} else if(tick == 2){
-			missileComponent.increasePower();
+			missileComponent.changePower(+1);
 			System.out.println("Shoot should be fired");
-				//field.deactivateWithCursor(gc.getVirtualX(cursorX), gc.getVirtualY(cursorY));
+				//field.decreaseStatIndicatedAt(gc.getVirtualX(cursorX), gc.getVirtualY(cursorY));
 			} else if(tick == 12) {
 				running = false;
 			}

--- a/se.liu.ida.l2.tddd78.psc/src/graphics/PSCFrame.java
+++ b/se.liu.ida.l2.tddd78.psc/src/graphics/PSCFrame.java
@@ -34,11 +34,7 @@ public class PSCFrame extends JFrame{
 		private class PSCMouseWheelListener implements MouseWheelListener {
 
 			@Override public void mouseWheelMoved(final MouseWheelEvent e) {
-				if (e.getWheelRotation() < 0) {
-					arena.activateWithCursor(gc.getVirtualX(e.getX()), gc.getVirtualY(e.getY()));
-				} else if (e.getWheelRotation() > 0){
-					arena.deactivateWithCursor(gc.getVirtualX(e.getX()), gc.getVirtualY(e.getY()));
-				}
+				arena.changeStatIndicatedAt(gc.getVirtualX(e.getX()), gc.getVirtualY(e.getY()), -e.getWheelRotation());
 			}
 		}
 

--- a/se.liu.ida.l2.tddd78.psc/src/shipcomponents/AbstractShipComponent.java
+++ b/se.liu.ida.l2.tddd78.psc/src/shipcomponents/AbstractShipComponent.java
@@ -110,88 +110,47 @@ public abstract class AbstractShipComponent extends GeneralVisibleEntity impleme
 		shieldingBar.draw(g, scale, screenX, screenY, shielding, MAXSHIELDING, hasShield());
 	}
 
-	/**
-	 * Performs activation action for this ship component, depending on where the cursor is relative to this ship component.
-	 * Increases the level of of any stat which indication bar the cursor hovers over.
-	 *
-	 * @param rx the cursor's virtual x-position relative to this ship component
-	 * @param ry the cursor's virtual y-position relative to this ship component
-	 */
-	@Override public void activateWithCursor(final float rx, final float ry) {
+	@Override public void changeStatIndicatedAt(final float rx, final float ry, final int change) {
 		if (powerBar.contains(rx, ry)) {
-			increasePower();
+			changePower(change);
 		} else if (shieldingBar.contains(rx, ry)) {
-			increaseShielding();
+			changeShielding(change);
 		}
 	}
 
 	/**
-	 * Performs deactivation action for this ship component, depending on where the cursor is relative to this ship component.
-	 * Decreases the level of of any stat which indication bar the cursor hovers over.
-	 *
-	 * @param rx the cursor's virtual x-position relative to this ship component
-	 * @param ry the cursor's virtual y-position relative to this ship component
-	 */
-	@Override public void deactivateWithCursor(final float rx, final float ry) {
-		if (powerBar.contains(rx, ry)) {
-			decreasePower();
-		} else if (shieldingBar.contains(rx, ry)) {
-			decreaseShielding();
+	  * Tries to change the shielding of the component by one by the specified amount.
+	  * Requests a visual update if successfull.
+	  *
+	  * @param change amount with which the shielding is to be changed
+	  * @return true if successfull, false if shielding is at max value
+	  */
+	@Override public boolean changeShielding(int change) {
+		int oldShielding = shielding;
+		if (change < 0) {
+			shielding = decreaseStat(shielding, 0);
+		} else {
+			shielding = increaseStat(shielding, MAXSHIELDING);
 		}
-	}
-
-	/**
-	 * Tries to increase the shielding of the component by one.
-	 * Requests a visual update if successfull.
-	 *
-	 * @return true if successfull
-	 */
-	@Override public boolean increaseShielding() {
-		int oldShielding = shielding;
-		shielding = increaseStat(shielding, MAXSHIELDING);
 		return hasChanged(shielding, oldShielding);
     }
 
 	/**
-	 * Tries to decrease the shielding of the component by one.
-	 * Requests a visual update if successfull.
-	 *
-	 * @return true if successfull
-	 */
-    @Override public boolean decreaseShielding() {
-		int oldShielding = shielding;
-		shielding = decreaseStat(shielding, 0);
-		return hasChanged(shielding, oldShielding);
-    }
-
-	/**
-	 * Tries to increase the power of the component by one.
-	 * Requests a visual update if successfull.
-	 *
-	 * @return true if successfull
-	 */
-    @Override public boolean increasePower() {
+	  * Tries to change the power of the component by one by the specified amount.
+	  * Requests a visual update if successfull.
+	  *
+	  * @param change amount with which the power is to be changed
+	  * @return true if successfull, false if power is at max value
+	  */
+	@Override public boolean changePower(final int change) {
 		int oldPower = power;
-		power = increaseStat(power, MAXPOWER);
+		if (change < 0) {
+			power = decreaseStat(power, 0);
+		} else {
+			power = increaseStat(power, MAXPOWER);
+		}
 		return hasChanged(power, oldPower);
-    }
-
-	/**
-	 * Tries to decrease the power of the component by one.
-	 * Requests a visual update if successfull.
-	 *
-	 * @return true if successfull
-	 */
-    @Override public boolean decreasePower() {
-		int oldPower = power;
-		power = decreaseStat(power, 0);
-		boolean hasChanged = power != oldPower;
-		if (hasChanged){
-			requestVisualUpdate();
-		}
-		return hasChanged;
-
-    }
+	}
 
 	/**
 	 * Returns true and requests an visual update if the the specified values differ.

--- a/se.liu.ida.l2.tddd78.psc/src/shipcomponents/ShipComponent.java
+++ b/se.liu.ida.l2.tddd78.psc/src/shipcomponents/ShipComponent.java
@@ -7,6 +7,7 @@ import java.awt.*;
 
 /**
  * Interface defining the ship component and general functions including once for recieving damage and activation.
+ * Has stats and a stat bar for them.
  */
 public interface ShipComponent extends VisibleEntity {
 
@@ -16,11 +17,6 @@ public interface ShipComponent extends VisibleEntity {
      * @param damage the number of hit points by which this ship component's HP is reduced
      */
     public void inflictDamage(int damage);
-
-    /**
-     * Activates this ship component, performing its component-type specific action.
-     */
-    public void performAction();
 
     /**
      * Draws this ship component with the specified scaling.
@@ -33,32 +29,30 @@ public interface ShipComponent extends VisibleEntity {
     public void draw(final Graphics g, final float scale, final float virtualX, final float virtualY);
 
     /**
-     * Tries to increase the shielding of the component by one.
+     * Tries to change the shielding of the component by the specified amount.
      *
-     * @return true if successfull
+	 * @param change amount with which the shielding is to be changed
+     * @return true if successfull, false if shielding is at max value
      */
-    public boolean increaseShielding();
+    public boolean changeShielding(int change);
 
-    /**
-     * Tries to decrease the shielding of the component by one.
-     *
-     * @return true if successfull
-     */
-    public boolean decreaseShielding();
+	/**
+	  * Tries to change the power of the component by the specified amount.
+	  *
+	  * @param change amount with which the power is to be changed
+	  * @return true if successfull, false if power is at max value
+	  */
+	 public boolean changePower(int change);
 
-    /**
-     * Tries to increase the power yo the component by one.
-     *
-     * @return true if successfull
-     */
-    public boolean increasePower();
-
-    /**
-     * Tries to decrease the power to the component by one.
-     *
-     * @return true if successfull
-     */
-    public boolean decreasePower();
+	/**
+	 * Tries to change the stat, which indicator bar is at the specified virtual position relative to this ship component,
+	 * with the specified amount.
+	 *
+	 * @param rx a virtual x-position relative to this ship component
+	 * @param ry a virtual y-position relative to this ship component
+	 * @param change amount with which the stat is to be changed
+	 */
+    public void changeStatIndicatedAt(final float rx, final float ry, int change);
 
     /**
      * @return true if this shipComponent is shielded.
@@ -97,20 +91,4 @@ public interface ShipComponent extends VisibleEntity {
      * @param ship the ship with which this component is registered.
      */
     public void registerFunctionality(StarShip ship);
-
-	/**
-	 * Performs activation action for this ship component, depending on where the cursor is relative to this ship component.
-	 *
-	 * @param rx the cursor's virtual x-position relative to this ship component
-	 * @param ry the cursor's virtual y-position relative to this ship component
-	 */
-    public void activateWithCursor(final float rx, final float ry);
-
-	/**
-	 * Performs deactivation action for this ship component, depending on where the cursor is relative to this ship component.
-	 *
-	 * @param rx the cursor's virtual x-position relative to this ship component
-	 * @param ry the cursor's virtual y-position relative to this ship component
-	 */
-    public void deactivateWithCursor(final float rx, final float ry);
 }

--- a/se.liu.ida.l2.tddd78.psc/src/shipcomponents/utilitycomponents/EngineComponent.java
+++ b/se.liu.ida.l2.tddd78.psc/src/shipcomponents/utilitycomponents/EngineComponent.java
@@ -23,10 +23,6 @@ public class EngineComponent extends UtilityComponent {
 	}
     }
 
-    @Override public void performAction() {
-
-    }
-
     @Override public void draw(final Graphics g, final float scale, final float virtualX, final float virtualY) {
 		draw(g, scale, virtualX, virtualY, Color.RED);
     }

--- a/se.liu.ida.l2.tddd78.psc/src/shipcomponents/utilitycomponents/ReactorComponent.java
+++ b/se.liu.ida.l2.tddd78.psc/src/shipcomponents/utilitycomponents/ReactorComponent.java
@@ -24,10 +24,6 @@ public class ReactorComponent extends UtilityComponent{
 	}
     }
 
-    @Override public void performAction() {
-
-    }
-
     @Override public void draw(final Graphics g, final float scale, final float virtualX, final float virtualY) {
 		draw(g, scale, virtualX, virtualY, Color.GREEN);
     }

--- a/se.liu.ida.l2.tddd78.psc/src/shipcomponents/utilitycomponents/ShieldComponent.java
+++ b/se.liu.ida.l2.tddd78.psc/src/shipcomponents/utilitycomponents/ShieldComponent.java
@@ -24,10 +24,6 @@ public class ShieldComponent extends UtilityComponent{
 	}
     }
 
-    @Override public void performAction() {
-
-    }
-
     @Override public void draw(final Graphics g, final float scale, final float virtualX, final float virtualY) {
 		draw(g, scale, virtualX, virtualY, Color.CYAN);
     }

--- a/se.liu.ida.l2.tddd78.psc/src/shipcomponents/weaponscomponents/MissileComponent.java
+++ b/se.liu.ida.l2.tddd78.psc/src/shipcomponents/weaponscomponents/MissileComponent.java
@@ -23,10 +23,6 @@ public class MissileComponent extends AbstractWeaponComponent
 
     }
 
-    @Override public void performAction() {
-
-    }
-
     @Override public void registerFunctionality(final StarShip ship) {
         ship.registerWeaponComponent(this);
     }


### PR DESCRIPTION
…stat X with a specified amount. For one, this reduces the number of methods (and therefore lowers needed maintenance) and it also allows mouse wheels that support "free scrolling" (Have no idea what this is really called) to scrolls multiple clicks and therefor change stats multiple levels. Contradictory to this, ships' strip pool method had be split into stripShielding and stripPower since they needed to call different methods (changeShielding and changePower respectively)